### PR TITLE
Added millisecond support for date conversion

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -345,7 +345,8 @@ function toSqlDate(date) {
 		('00' + date.getUTCDate()).slice(-2) + ' ' +
 		('00' + date.getUTCHours()).slice(-2) + ':' +
 		('00' + date.getUTCMinutes()).slice(-2) + ':' +
-		('00' + date.getUTCSeconds()).slice(-2);
+		('00' + date.getUTCSeconds()).slice(-2) + '.' +
+		('000' + date.getUTCMilliseconds()).slice(-3);
 
 	return date;
 }


### PR DESCRIPTION
This commit adds the ability to save milliseconds to MSSQL's datetime field. 

In general MSSQL's datetime millisecond precision rounds to the nearest 1/333 second so there will always be rounding errors.

See here for the results after this commit was pushed to my local environment:

![sqlscreengrab](https://cloud.githubusercontent.com/assets/8022749/13516913/90c96d9e-e17b-11e5-810c-e7cc9be3935c.png)
